### PR TITLE
Prevent formatting unchanged files during apply-git

### DIFF
--- a/phpcf-src/src/cli/git/GitCallback.php
+++ b/phpcf-src/src/cli/git/GitCallback.php
@@ -94,14 +94,15 @@ class GitCallback
                 $commits_arg = Helper::commitsArg(null);
                 $lines = Helper::changedLines($file, $commits_arg, $file_statuses[$file]);
                 $lines = implode(',', $lines);
+
                 $Ctx->removeFile($file);
                 if ($lines) {
                     $file .= ':' . $lines;
-                } else {
-                    // if file has no changed lines - do not try to do anything with it
-                    continue;
                 }
-                $Ctx->addFile($file);
+
+                if ($lines || ($file_statuses[$file] !== 'M' && $file_statuses[$file] !== Helper::INVALID_STATUS)) {
+                    $Ctx->addFile($file);
+                }
             }
         } else {
             $files = $Ctx->getFiles();
@@ -119,8 +120,8 @@ class GitCallback
 
                 $Ctx->removeFile($file);
 
-                if ($lines) {
-                    $Ctx->addFile($file . implode(',', $lines));
+                if ($lines || ($file_statuses[$file] !== 'M' && $file_statuses[$file] !== Helper::INVALID_STATUS)) {
+                    $Ctx->addFile($file . ($lines ? ':' . implode(',', $lines) : ''));
                 }
             }
         }

--- a/phpcf-src/src/cli/git/GitCallback.php
+++ b/phpcf-src/src/cli/git/GitCallback.php
@@ -117,9 +117,10 @@ class GitCallback
                 $commits_arg = Helper::commitsArg(null);
                 $lines = Helper::changedLines($file, $commits_arg, $file_statuses[$file]);
 
+                $Ctx->removeFile($file);
+
                 if ($lines) {
-                    $Ctx->removeFile($file);
-                    $Ctx->addFile($file . ':' . implode(',', $lines));
+                    $Ctx->addFile($file . implode(',', $lines));
                 }
             }
         }


### PR DESCRIPTION
Hi!

In this PR I've done 2 things:

1. First of all, as you can expect from the title, — if you run `apply-git` over a file which you haven't changed, it wouldn't be re-formatted
2. Untracked and ignored files are now properly being formatted with `apply-git`, previously they were causing an error.